### PR TITLE
Readme: Changed to "npm-enforce-version" (from "npm-version-check")

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NPM Version Check
+# NPM Enforce Version
 
 Check a version of NPM is properly installed. Enforce a version of NPM on your dev or production environment.
 
@@ -6,6 +6,6 @@ Check a version of NPM is properly installed. Enforce a version of NPM on your d
 
 Simply add this package to your dependencies at the version you want to enforce, e.g.
 
-```npm install --save npm-version-check@2.6.1```
+```npm install --save npm-enforce-version@2.6.1```
 
 If someone installs your package without having a version superior to the one specified, installation will fail.


### PR DESCRIPTION
I noticed the package is named "npm-enforce-version" but the Readme instructed you to install "npm-version-check" (which didn't work in practise. Hence I've updated the readme to use the right package name (which is possible to install with).
